### PR TITLE
Update gemspec to reflect homepage and rspec dependency

### DIFF
--- a/gsa.gemspec
+++ b/gsa.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   "internal search".
   }
 
-  spec.homepage      = 'https://rubygems.org/gems/gsa'
+  spec.homepage      = 'https://github.com/1000Bulbs/gsa'
   spec.license       = 'MIT'
   
   spec.files         = `git ls-files`.split($/)
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 1.13.0'
   spec.add_development_dependency 'vcr', '~> 2.5.0'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
+  spec.add_development_dependency 'rspec', '~> 2.13.0'
 
   spec.add_runtime_dependency 'rest-client', '~> 1.6.7'
   spec.add_runtime_dependency 'activesupport', '~> 4.0.0'


### PR DESCRIPTION
Now that it's open sourced, I've pointed the homepage link to the Github repo.

I also noticed that rspec wasn't included as a development dependency. So I added that as well.
