### PR TITLE
JRuby support / Nokogiri

### DIFF
--- a/gsa.gemspec
+++ b/gsa.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage      = 'https://github.com/1000Bulbs/gsa'
   spec.license       = 'MIT'
-  
+
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rest-client', '~> 1.6.7'
   spec.add_runtime_dependency 'activesupport', '~> 4.0.0'
   spec.add_runtime_dependency 'json', '~> 1.8.0'
-  spec.add_runtime_dependency 'libxml-ruby', '~> 2.7.0'
+  spec.add_runtime_dependency 'nokogiri', '> 1.5.0'
 end

--- a/lib/defaults.rb
+++ b/lib/defaults.rb
@@ -4,7 +4,7 @@ module Defaults
 
   # feed extension
   FEED_EXTENSION         = ":19902/xmlfeed"
-  
+
   # feed actions
   ADD_ACTION             = "add"
   DELETE_ACTION          = "delete"

--- a/lib/gsa.rb
+++ b/lib/gsa.rb
@@ -20,7 +20,7 @@ require_relative 'gsa/readable_results/readable_result_sets'
 require_relative 'defaults'
 require_relative 'facade'
 
-ActiveSupport::XmlMini.backend = 'LibXML'
+ActiveSupport::XmlMini.backend = 'Nokogiri'
 
 module GSA
   class << self


### PR DESCRIPTION
Hi, Thanks for the great work on this gem!

I'd love to use this gem, but I work in an area where we often deploy to JRuby. We can't use it because LibXML requires C-extensions, so that doesn't really work in JRuby. We actually used it in a hackathon and found out half-way through that we can only use it from MRI.

Would you guys be open to a pull request that converts the XML parsing to Nokogiri from LibXML? 

Nokogiri works great in JRuby (has a native Java fork) and has fewer dependencies in MRI than LibXML, so I think overall it'd be a useful thing for the gem.
